### PR TITLE
feat: added search for directory to strategies for connecting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.97"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+
+[[package]]
 name = "clap"
 version = "4.5.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -287,6 +293,7 @@ dependencies = [
 name = "zesh"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap",
  "thiserror 1.0.69",
  "zellij_rs",

--- a/zesh/Cargo.toml
+++ b/zesh/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/roberte777/zesh/zesh"
 readme="../README.md"
 
 [dependencies]
+anyhow = "1.0.97"
 clap = { version = "4.4", features = ["derive"] }
 thiserror = "1.0"
 zellij_rs = { path = "../zellij_rs", version = "0.1.0"}


### PR DESCRIPTION
Adds the possibility to specify a filepath to connect to. Zesh will now search in the following order:
- Active sessions
- Directories
- Zoxide