### PR TITLE
Add missing score argument

### DIFF
--- a/zox_rs/src/lib.rs
+++ b/zox_rs/src/lib.rs
@@ -74,7 +74,11 @@ impl ZoxideOperations for ZoxideClient {
     }
 
     fn list(&self) -> ZoxideResult<Vec<ZoxideEntry>> {
-        let output = Command::new("zoxide").arg("query").arg("--list").output()?;
+        let output = Command::new("zoxide")
+            .arg("query")
+            .arg("--list")
+            .arg("--score")
+            .output()?;
 
         if !output.status.success() {
             let error = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
This minor PR fixes the Zellij list command, since missing score data causes a `ZoxideError::OutputParsing` error. 

There's a possible redundant `parse_zoxide_query_output` function that can be cleaned up after this change. Let me know if there was another use for it or if it can be removed.