### PR TITLE
Check Git Dir for Session Names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,11 +168,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -286,7 +286,7 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 name = "zellij_rs"
 version = "0.1.0"
 dependencies = [
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -297,12 +297,20 @@ dependencies = [
  "clap",
  "thiserror 1.0.69",
  "zellij_rs",
+ "zesh_git",
  "zox_rs",
+]
+
+[[package]]
+name = "zesh_git"
+version = "0.1.0"
+dependencies = [
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "zox_rs"
 version = "0.1.0"
 dependencies = [
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = [
     "zellij_rs",
-    "zesh",
+    "zesh", "zesh_git",
     "zox_rs",
 ]
 resolver = "2"

--- a/zesh/Cargo.toml
+++ b/zesh/Cargo.toml
@@ -13,3 +13,4 @@ clap = { version = "4.4", features = ["derive"] }
 thiserror = "1.0"
 zellij_rs = { path = "../zellij_rs", version = "0.1.0"}
 zox_rs = { path = "../zox_rs", version = "0.1.0"}
+zesh_git = { path = "../zesh_git", version = "0.1.0"}

--- a/zesh/src/main.rs
+++ b/zesh/src/main.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use zesh::connection::ConnectService;
 use zesh::fs::RealFs;
+use zesh_git::RealGit;
 
 use zellij_rs::{ZellijClient, ZellijOperations};
 use zox_rs::{ZoxideClient, ZoxideOperations};
@@ -63,8 +64,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let zellij = ZellijClient::new();
     let zoxide = ZoxideClient::new();
     let fs = RealFs::new();
+    let git = RealGit;
 
-    let connect_service = ConnectService::new(zellij, zoxide, fs);
+    let connect_service = ConnectService::new(zellij, zoxide, fs, git);
 
     match &cli.command {
         Commands::List => {

--- a/zesh_git/Cargo.toml
+++ b/zesh_git/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "zesh_git"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+thiserror = "2.0.12"

--- a/zesh_git/src/lib.rs
+++ b/zesh_git/src/lib.rs
@@ -1,0 +1,116 @@
+use std::process::Command;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum GitError {
+    #[error("failed to execute command: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("git command error: {0}")]
+    CommandError(String),
+}
+
+/// A trait representing Git operations.
+pub trait Git {
+    /// Runs `git rev-parse --show-toplevel` in the given directory.
+    /// Returns a tuple where the first element is `true` if the command succeeded,
+    /// and the second element is either the top-level directory path or the error output.
+    fn show_top_level(&self, name: &str) -> Result<(bool, String), GitError>;
+
+    /// Runs `git rev-parse --git-common-dir` in the given directory.
+    /// Returns a tuple where the first element is `true` if the command succeeded,
+    /// and the second element is either the common directory path or the error output.
+    fn git_common_dir(&self, name: &str) -> Result<(bool, String), GitError>;
+
+    /// Runs `git clone <url> <dir>` in the given command directory.
+    /// Returns the output string on success.
+    fn clone(&self, url: &str, cmd_dir: &str, dir: &str) -> Result<String, GitError>;
+}
+
+/// A real implementation of the Git trait that calls the actual git commands.
+pub struct RealGit;
+
+impl Git for RealGit {
+    fn show_top_level(&self, name: &str) -> Result<(bool, String), GitError> {
+        let output = Command::new("git")
+            .args(["-C", name, "rev-parse", "--show-toplevel"])
+            .output()?;
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Ok((true, stdout))
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Ok((false, stderr))
+        }
+    }
+
+    fn git_common_dir(&self, name: &str) -> Result<(bool, String), GitError> {
+        let output = Command::new("git")
+            .args(["-C", name, "rev-parse", "--git-common-dir"])
+            .output()?;
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Ok((true, stdout))
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Ok((false, stderr))
+        }
+    }
+
+    fn clone(&self, url: &str, cmd_dir: &str, dir: &str) -> Result<String, GitError> {
+        let output = Command::new("git")
+            .args(["clone", url, dir])
+            .current_dir(cmd_dir)
+            .output()?;
+        if output.status.success() {
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            Ok(stdout)
+        } else {
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+            Err(GitError::CommandError(stderr))
+        }
+    }
+}
+
+/// A mocked implementation of the Git trait for testing purposes.
+pub struct MockGit;
+
+impl Git for MockGit {
+    fn show_top_level(&self, _name: &str) -> Result<(bool, String), GitError> {
+        // Always return a mocked top-level directory.
+        Ok((true, String::from("/mock/repo/top-level")))
+    }
+
+    fn git_common_dir(&self, _name: &str) -> Result<(bool, String), GitError> {
+        // Always return a mocked common directory.
+        Ok((true, String::from("/mock/repo/common-dir")))
+    }
+
+    fn clone(&self, _url: &str, _cmd_dir: &str, _dir: &str) -> Result<String, GitError> {
+        // Always return a success message.
+        Ok(String::from("Mock clone successful"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_mock_git() {
+        let git = MockGit;
+
+        let (success, top_level) = git.show_top_level("any_dir").unwrap();
+        assert!(success);
+        assert_eq!(top_level, "/mock/repo/top-level");
+
+        let (success, common_dir) = git.git_common_dir("any_dir").unwrap();
+        assert!(success);
+        assert_eq!(common_dir, "/mock/repo/common-dir");
+
+        let clone_output = git
+            .clone("https://example.com/repo.git", ".", "repo")
+            .unwrap();
+        assert_eq!(clone_output, "Mock clone successful");
+    }
+}


### PR DESCRIPTION
This pull request will check if the folder is in a git dir when deciding on the name for the session. For example, if you git repository is foo/bar/baz and you use zesh cn baz, the session name will be foo_bar_baz. Underscores have to be used because "/" is not allowed in session names for zellij